### PR TITLE
Remove the need for vc forceclose to require vc Dispute sigs

### DIFF
--- a/channel/adjudicator/adjudicator.go
+++ b/channel/adjudicator/adjudicator.go
@@ -49,7 +49,7 @@ func (a Adjudicator) Withdraw(ctx context.Context, req channel.AdjudicatorReq, s
 			// Force Close with Virtual Channel.
 			for _, vcstate := range stateMap {
 				indexMap := req.Tx.Locked[0].IndexMap
-				return a.client.ForceCloseWithVC(ctx, req.Tx.ID, vcstate.State.ID, req.Tx.State, vcstate.State, req.Tx.Sigs, vcstate.Sigs, req.Params, indexMap)
+				return a.client.ForceCloseWithVC(ctx, req.Tx.ID, vcstate.State.ID, req.Tx.State, vcstate.State, req.Tx.Sigs, req.Params, indexMap)
 			}
 		}
 

--- a/client/ckbclient.go
+++ b/client/ckbclient.go
@@ -72,7 +72,7 @@ type CKBClient interface {
 	// The implementation can assume that the channel has already been disputed and that the challenge duration
 	// is expired in real-time, though it may be necessary to wait until a block is produced with a timestamp strictly
 	// later than the expiration of the challenge duration.
-	ForceCloseWithVC(ctx context.Context, id channel.ID, vcid channel.ID, state *channel.State, vcstate *channel.State, sigs []wallet.Sig, vcSigs []wallet.Sig, params *channel.Params, indexMap []channel.Index) error
+	ForceCloseWithVC(ctx context.Context, id channel.ID, vcid channel.ID, state *channel.State, vcstate *channel.State, sigs []wallet.Sig, params *channel.Params, indexMap []channel.Index) error
 
 	// GetChannelWithID returns an on-chain channel with the given channel ID.
 	// Note: Only the channel ID field in the state must be checked, as the pcts verifies the integrity of said
@@ -697,7 +697,7 @@ func (c Client) ForceClose(ctx context.Context, id channel.ID, state *channel.St
 	return c.submitTx(ctx, tx)
 }
 
-func (c Client) ForceCloseWithVC(ctx context.Context, id channel.ID, vcid channel.ID, state *channel.State, vcstate *channel.State, sigs []wallet.Sig, vcSigs []wallet.Sig, params *channel.Params, indexMap []channel.Index) error {
+func (c Client) ForceCloseWithVC(ctx context.Context, id channel.ID, vcid channel.ID, state *channel.State, vcstate *channel.State, sigs []wallet.Sig, params *channel.Params, indexMap []channel.Index) error {
 	virtualChannelCells, vcStatuses, err := c.getVirtualChannelLiveCellWithCache(ctx, vcid)
 	if err != nil {
 		return fmt.Errorf("getting virtual channel live cell: %w", err)
@@ -737,18 +737,6 @@ func (c Client) ForceCloseWithVC(ctx context.Context, id channel.ID, vcid channe
 		return fmt.Errorf("encoding signature B: %w", err)
 	}
 
-	vcSigA, err := encoding.NewDEREncodedSignatureFromPadded(vcSigs[0])
-	if err != nil {
-		return fmt.Errorf("encoding signature A: %w", err)
-	}
-
-	vcSigB, err := encoding.NewDEREncodedSignatureFromPadded(vcSigs[1])
-	if err != nil {
-		return fmt.Errorf("encoding signature B: %w", err)
-	}
-
-	vcDispute := encoding.PackVCDispute(vcSigA, vcSigB, sigA, sigB)
-
 	header, err := c.client.GetTipHeader(ctx)
 	if err != nil {
 		return fmt.Errorf("getting tip header: %w", err)
@@ -779,7 +767,6 @@ func (c Client) ForceCloseWithVC(ctx context.Context, id channel.ID, vcid channe
 		vcstate,
 		vcStatus,
 		*sigA, *sigB,
-		&vcDispute,
 		params,
 		[]types.Hash{header.Hash, *blockHash},
 		mkCellInputs(assets),

--- a/transaction/forceclosewithvc.go
+++ b/transaction/forceclosewithvc.go
@@ -19,9 +19,8 @@ type ForceCloseWithVCInfo struct {
 	Headers     []types.Hash
 	AssetInputs []types.CellInput
 
-	SigA      molecule.Bytes
-	SigB      molecule.Bytes
-	VCDispute *molecule.VCDispute
+	SigA molecule.Bytes
+	SigB molecule.Bytes
 
 	ChannelCapacity        uint64
 	VirtualChannelCapacity uint64
@@ -42,7 +41,6 @@ func NewForceCloseWithVCInfo(
 	vcStatus *molecule.VirtualChannelStatus,
 	sigA molecule.Bytes,
 	sigB molecule.Bytes,
-	vcDispute *molecule.VCDispute,
 	params *channel.Params,
 	headers []types.Hash,
 	assetInputs []types.CellInput,
@@ -60,7 +58,6 @@ func NewForceCloseWithVCInfo(
 		VCStatus:               vcStatus,
 		SigA:                   sigA,
 		SigB:                   sigB,
-		VCDispute:              vcDispute,
 		Params:                 params,
 		Headers:                headers,
 		AssetInputs:            assetInputs,

--- a/transaction/handler.go
+++ b/transaction/handler.go
@@ -570,13 +570,10 @@ func (psh *PerunScriptHandler) buildFirstForceCloseWithVCTransaction(builder col
 	}
 
 	// Virtual channel cell input.
-	vcInputIndex := builder.AddInput(&types.CellInput{
+_:
+	builder.AddInput(&types.CellInput{
 		PreviousOutput: &forceCloseWithVCInfo.VCCell,
 	})
-	err = builder.SetWitness(uint(vcInputIndex), types.WitnessTypeInputType, psh.mkWitnessVCDispute(forceCloseWithVCInfo.VCDispute))
-	if err != nil {
-		return false, err
-	}
 
 	for _, assetInput := range forceCloseWithVCInfo.AssetInputs {
 		builder.AddInput(&assetInput)
@@ -654,14 +651,9 @@ func (psh *PerunScriptHandler) buildSecondForceCloseWithVCTransaction(builder co
 	}
 
 	// Virtual channel cell input.
-	vcInputIndex := builder.AddInput(&types.CellInput{
+	_ = builder.AddInput(&types.CellInput{
 		PreviousOutput: &forceCloseWithVCInfo.VCCell,
 	})
-	err = builder.SetWitness(uint(vcInputIndex), types.WitnessTypeInputType, psh.mkWitnessVCDispute(forceCloseWithVCInfo.VCDispute))
-	if err != nil {
-		return false, err
-	}
-
 	for _, assetInput := range forceCloseWithVCInfo.AssetInputs {
 		builder.AddInput(&assetInput)
 	}


### PR DESCRIPTION
This makes the upgrade to higher version of go-perun cleaner and allow the inclusion  of virtual channel in the future
